### PR TITLE
fix(dart-board): remove optional bootstrap dependency

### DIFF
--- a/packages/dart-board/package.json
+++ b/packages/dart-board/package.json
@@ -56,7 +56,6 @@
   },
   "peerDependencies": {
     "@arcgis/core": "^4.20.0",
-    "bootstrap": "^4.5.3",
     "prop-types": "^15.8.1",
     "react": ">=16.8.0"
   }


### PR DESCRIPTION
it should be trivial to expect to have a bootstrap or tailwind css file imported to use those named components