### PR TITLE
feat(layer-selector): add optional opacity slider and some fixes and refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ Please use [conventional commits](https://www.conventionalcommits.org) with the 
 ### NPM Linking
 
 To test these packages in other local projects, first run `npm link -workspaces` from the root of this project. Then run `npm link @ugrc/dart-board @ugrc/sherlock` from the root of your test project. Please note that you need to run `npm link` for all of the packages at the same time or previous ones will be removed.
+
+Then run `npm run build:watch --workspace packages/dart-board` to automatically build the package any time a file is saved.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@types/arcgis-js-api": "^4.24.0",
         "@vitejs/plugin-react": "^2.0.0",
         "babel-loader": "^8.2.5",
+        "chokidar-cli": "^3.0.0",
         "eslint": "^8.21.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
@@ -8656,23 +8657,218 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.4.3",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
-      "license": "MIT",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "glob-parent": "~5.1.0",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       },
       "engines": {
         "node": ">= 8.10.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.1.2"
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar-cli": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-3.0.0.tgz",
+      "integrity": "sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "yargs": "^13.3.0"
+      },
+      "bin": {
+        "chokidar": "index.js"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/chokidar-cli/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "node_modules/chokidar-cli/node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     },
     "node_modules/chokidar/node_modules/binary-extensions": {
@@ -8681,18 +8877,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/chokidar/node_modules/fsevents": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/chokidar/node_modules/is-binary-path": {
@@ -8707,9 +8891,10 @@
       }
     },
     "node_modules/chokidar/node_modules/readdirp": {
-      "version": "3.5.0",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -15110,6 +15295,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "dev": true
+    },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
       "dev": true,
@@ -18727,6 +18918,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -22657,6 +22854,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
+      "dev": true
     },
     "node_modules/wide-align": {
       "version": "1.1.5",
@@ -27431,8 +27634,8 @@
     "@ugrc/sherlock": {
       "version": "file:packages/sherlock",
       "requires": {
-        "@fortawesome/fontawesome-svg-core": "6.1.2",
-        "@fortawesome/free-solid-svg-icons": "6.1.2",
+        "@fortawesome/fontawesome-svg-core": "^6.1.2",
+        "@fortawesome/free-solid-svg-icons": "^6.1.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "downshift": "^6.1.7",
         "lodash-es": "^4.17.21",
@@ -28728,27 +28931,24 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.4.3",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       },
       "dependencies": {
         "binary-extensions": {
           "version": "2.1.0",
           "dev": true
-        },
-        "fsevents": {
-          "version": "2.1.3",
-          "dev": true,
-          "optional": true
         },
         "is-binary-path": {
           "version": "2.1.0",
@@ -28758,10 +28958,163 @@
           }
         },
         "readdirp": {
-          "version": "3.5.0",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
           "dev": true,
           "requires": {
             "picomatch": "^2.2.1"
+          }
+        }
+      }
+    },
+    "chokidar-cli": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-3.0.0.tgz",
+      "integrity": "sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.2",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "yargs": "^13.3.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -33035,6 +33388,12 @@
       "version": "4.6.2",
       "dev": true
     },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "dev": true
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "dev": true
@@ -35466,6 +35825,12 @@
       "version": "2.0.2",
       "dev": true,
       "peer": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
     },
     "resolve": {
       "version": "1.22.1",
@@ -38135,6 +38500,12 @@
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
       }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
+      "dev": true
     },
     "wide-align": {
       "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/arcgis-js-api": "^4.24.0",
     "@vitejs/plugin-react": "^2.0.0",
     "babel-loader": "^8.2.5",
+    "chokidar-cli": "^3.0.0",
     "eslint": "^8.21.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",

--- a/packages/dart-board/package.json
+++ b/packages/dart-board/package.json
@@ -47,6 +47,7 @@
   ],
   "scripts": {
     "build": "vite build --config ../../vite.config.js",
+    "build:watch": "chokidar \"src/**/*.(js|jsx|css)\" -c \"npm run build\"",
     "test": "vitest --config ../../vite.config.js"
   },
   "dependencies": {

--- a/packages/layer-selector/package.json
+++ b/packages/layer-selector/package.json
@@ -48,6 +48,7 @@
   ],
   "scripts": {
     "build": "vite build --config ../../vite.config.js",
+    "build:watch": "chokidar \"src/**/*.(js|jsx|css)\" -c \"npm run build\"",
     "test": "vitest --config ../../vite.config.js"
   },
   "dependencies": {

--- a/packages/layer-selector/src/LayerSelector.css
+++ b/packages/layer-selector/src/LayerSelector.css
@@ -1,47 +1,31 @@
 .layer-selector-item {
   margin: 0 8px;
 }
-.layer-selector--item {
-  max-width: 100px;
+.layer-selector-item--text {
   overflow: hidden;
   -o-text-overflow: ellipsis;
   text-overflow: ellipsis;
-  display: inline-block;
   font-size: 90%;
+  max-width: 100px;
+  white-space: nowrap;
+}
+.layer-selector--item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   user-select: none;
 }
-.layer-selector-item-input {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
-  padding: 0;
-  margin: 4px 0 0;
-  outline: thin dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
-  position: relative;
-  display: block;
+.layer-selector-item {
+  margin: 0.5em;
 }
-.layer-selector-item.radio,
-.layer-selector-item.checkbox {
-  position: relative;
-  margin-top: 0px;
-  margin-bottom: 0px;
+.layer-selector-item:first-child {
+  margin-top: 0;
 }
-.layer-selector-item.radio input[type='checkbox'],
-.layer-selector-item.checkbox input[type='checkbox'],
-.layer-selector-item.radio input[type='radio'],
-.layer-selector-item.checkbox input[type='radio'] {
-  position: absolute;
-  margin-left: -20px;
-}
-.layer-selector-item.radio label,
-.layer-selector-item.checkbox label {
-  min-height: 20px;
-  padding-left: 20px;
+.layer-selector-item:last-child {
   margin-bottom: 0;
-  font-weight: 400;
-  cursor: pointer;
+}
+.layer-selector-item input {
+  margin: 0 0.5em 0 0;
 }
 .layer-selector {
   background: #fff;

--- a/packages/layer-selector/src/LayerSelector.jsx
+++ b/packages/layer-selector/src/LayerSelector.jsx
@@ -25,6 +25,7 @@ const ExpandableContainer = (props) => {
   const fromClasses = classNames({ 'layer-selector--hidden': !expanded });
 
   return (
+    // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
     <div
       className="layer-selector"
       // onFocus={() => setExpanded(true)}

--- a/packages/layer-selector/src/LayerSelector.jsx
+++ b/packages/layer-selector/src/LayerSelector.jsx
@@ -8,6 +8,12 @@ import Basemap from '@arcgis/core/Basemap';
 import LOD from '@arcgis/core/layers/support/LOD';
 import TileInfo from '@arcgis/core/layers/support/TileInfo';
 import WebTileLayer from '@arcgis/core/layers/WebTileLayer';
+import FeatureLayer from '@arcgis/core/layers/FeatureLayer';
+
+const commonFactories = {
+  FeatureLayer,
+  WebTileLayer,
+};
 
 const ExpandableContainer = (props) => {
   const [expanded, setExpanded] = useState(props.expanded);
@@ -148,6 +154,14 @@ const createLayerFactories = (
 
       if (!li.selected) {
         li.selected = false;
+      }
+
+      if (typeof li.Factory === 'string') {
+        li.Factory = commonFactories[li.Factory];
+
+        if (!li.Factory) {
+          throw new Error(`Unknown layer factory: ${li.Factory}`);
+        }
       }
 
       resolvedInfos.push(li);

--- a/packages/layer-selector/src/LayerSelector.jsx
+++ b/packages/layer-selector/src/LayerSelector.jsx
@@ -55,12 +55,11 @@ const LayerSelectorItem = (props) => {
     <div className="layer-selector-item radio checkbox">
       <label className="layer-selector--item">
         <input
-          className="layer-selector-item-input"
           {...inputOptions}
           checked={props.selected}
           onChange={(event) => props.onChange(event, props)}
         />
-        {inputOptions.value}
+        <span className="layer-selector-item--text">{inputOptions.value}</span>
       </label>
     </div>
   );

--- a/packages/layer-selector/src/LayerSelector.jsx
+++ b/packages/layer-selector/src/LayerSelector.jsx
@@ -330,14 +330,12 @@ const LayerSelector = (props) => {
       ) || [];
     let overlays = props.overlays || [];
 
-    let hasDefaultSelection = false;
     let defaultSelection = null;
     let hasHybrid = false;
     let linkedLayersBuilder = [];
 
     baseLayers.forEach((layer) => {
       if (layer.selected === true) {
-        hasDefaultSelection = true;
         defaultSelection = layer;
       }
 
@@ -352,7 +350,7 @@ const LayerSelector = (props) => {
     setLinkedLayers(linkedLayersBuilder);
 
     // set default basemap to index 0 if not specified by the user
-    if (!hasDefaultSelection && baseLayers.length > 0) {
+    if (!defaultSelection && baseLayers.length > 0) {
       baseLayers[0].selected = true;
       defaultSelection = baseLayers[0];
     }
@@ -390,9 +388,14 @@ const LayerSelector = (props) => {
     });
 
     props.view.ui.add(selectorNode.current, props.position);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.modules]);
+  }, [
+    props.baseLayers,
+    props.overlays,
+    props.position,
+    props.quadWord,
+    props.view.map,
+    props.view.ui,
+  ]);
 
   const onItemChanged = (event, props) => {
     console.log('LayerSelector.onItemChanged', props);

--- a/packages/layer-selector/src/LayerSelector.jsx
+++ b/packages/layer-selector/src/LayerSelector.jsx
@@ -182,6 +182,16 @@ const LayerSelector = (props) => {
   const [managedLayers, setManagedLayers] = useState({});
   const selectorNode = useRef();
 
+  const [opacity, setOpacity] = useState(1);
+  useEffect(() => {
+    for (const layerId in managedLayers) {
+      const managedLayer = managedLayers[layerId];
+      if (managedLayer.layer) {
+        managedLayer.layer.opacity = opacity;
+      }
+    }
+  }, [managedLayers, opacity]);
+
   useEffect(() => {
     const managedLayersDraft = { ...managedLayers };
     const layerItems = layers.baseLayers.concat(layers.overlays);
@@ -204,7 +214,7 @@ const LayerSelector = (props) => {
           layerList = props.view.map.layers;
           break;
         default:
-          break;
+          throw new Error(`unknown layerType: ${layerItem.layerType}`);
       }
 
       if (layerItem.selected === false) {
@@ -374,7 +384,7 @@ const LayerSelector = (props) => {
       ) || [];
 
     // set visibility of linked layers to match
-    if (defaultSelection.linked && defaultSelection.linked.length > 0) {
+    if (defaultSelection?.linked && defaultSelection.linked.length > 0) {
       overlays.forEach((layer) => {
         if (defaultSelection.linked.includes(layer.id)) {
           layer.selected = true;
@@ -456,7 +466,9 @@ const LayerSelector = (props) => {
               key={index}
             />
           ))}
-          <hr className="layer-selector-separator" />
+          {layers.overlays.length ? (
+            <hr className="layer-selector-separator" />
+          ) : null}
           {layers.overlays.map((item) => (
             <LayerSelectorItem
               id={item.name || item.id || 'unknown'}
@@ -466,6 +478,21 @@ const LayerSelector = (props) => {
               key={item.id || item}
             />
           ))}
+          {props.showOpacitySlider ? (
+            <>
+              <hr className="layer-selector-separator" />
+              <input
+                type="range"
+                min="0"
+                max="100"
+                step="1"
+                value={opacity * 100}
+                onChange={(event) =>
+                  setOpacity(parseFloat(event.target.value) / 100.0)
+                }
+              />
+            </>
+          ) : null}
         </div>
       </ConditionalWrapper>
     </div>
@@ -538,11 +565,13 @@ LayerSelector.propTypes = {
   makeExpandable: PropTypes.bool,
   layerType: PropTypes.string,
   id: PropTypes.string,
+  showOpacitySlider: PropTypes.bool,
 };
 
 LayerSelector.defaultProps = {
   makeExpandable: true,
   position: 'top-right',
+  showOpacitySlider: false,
 };
 
 LayerSelectorItem.propTypes = {

--- a/packages/layer-selector/src/LayerSelector.stories.jsx
+++ b/packages/layer-selector/src/LayerSelector.stories.jsx
@@ -36,3 +36,21 @@ export const withoutExpandableContainer = () => (
     overlays={['Address Points']}
   ></LayerSelector>
 );
+
+export const defaultSelection = () => (
+  <LayerSelector
+    baseLayers={[
+      'Lite',
+      'Terrain',
+      {
+        token: 'Topo',
+        selected: true,
+      },
+      'Color IR',
+    ]}
+    view={mapViewMock}
+    quadWord="my-fake-quad-word"
+    makeExpandable={false}
+    overlays={['Address Points']}
+  ></LayerSelector>
+);

--- a/packages/layer-selector/src/LayerSelector.stories.jsx
+++ b/packages/layer-selector/src/LayerSelector.stories.jsx
@@ -6,7 +6,12 @@ export default {
   component: LayerSelector,
 };
 const mapViewMock = {
-  map: {},
+  map: {
+    layers: [],
+    basemap: {
+      layers: [],
+    },
+  },
   when: () => {},
   ui: {
     add: () => {},
@@ -27,5 +32,6 @@ export const withoutExpandableContainer = () => (
     view={mapViewMock}
     quadWord="my-fake-quad-word"
     makeExpandable={false}
+    overlays={['Address Points']}
   ></LayerSelector>
 );

--- a/packages/layer-selector/src/LayerSelector.stories.jsx
+++ b/packages/layer-selector/src/LayerSelector.stories.jsx
@@ -1,5 +1,6 @@
 import LayerSelector from './';
 import './LayerSelector.css';
+import Collection from '@arcgis/core/core/Collection';
 
 export default {
   title: 'LayerSelector',
@@ -7,9 +8,9 @@ export default {
 };
 const mapViewMock = {
   map: {
-    layers: [],
+    layers: new Collection(),
     basemap: {
-      layers: [],
+      layers: new Collection(),
     },
   },
   when: () => {},

--- a/packages/layer-selector/src/LayerSelectorItem.stories.jsx
+++ b/packages/layer-selector/src/LayerSelectorItem.stories.jsx
@@ -38,3 +38,11 @@ export const checkedOverlay = () => (
     id="Overlay Layer"
   />
 );
+export const longLabel = () => (
+  <LayerSelectorItem
+    layerType="overlay"
+    selected={true}
+    onChange={() => {}}
+    id="Overlay Layer A Longer Label"
+  />
+);

--- a/packages/layer-selector/src/LayerSelectorWithMap.stories.jsx
+++ b/packages/layer-selector/src/LayerSelectorWithMap.stories.jsx
@@ -120,6 +120,7 @@ export const customLOD = () => {
 
   return <WithMap zoom={6} baseLayers={baseLayers} />;
 };
+
 export const linkedOverlays = () => {
   const baseLayers = [
     {
@@ -152,6 +153,37 @@ export const linkedOverlays = () => {
   return <WithMap zoom={6} baseLayers={baseLayers} overlays={overlays} />;
 };
 
+export const defaultSelection = () => {
+  const baseLayers = [
+    {
+      Factory: TileLayer,
+      url: 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer',
+      id: 'Topo',
+    },
+    {
+      Factory: TileLayer,
+      url: 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer',
+      id: 'Terrain',
+      selected: true,
+    },
+  ];
+
+  const overlays = [
+    {
+      Factory: FeatureLayer,
+      url: 'https://services1.arcgis.com/99lidPhWCzftIe9K/arcgis/rest/services/UtahMunicipalBoundaries/FeatureServer/0',
+      id: 'Cities',
+      selected: true,
+    },
+    {
+      Factory: FeatureLayer,
+      url: 'https://services1.arcgis.com/99lidPhWCzftIe9K/arcgis/rest/services/UtahCountyBoundaries/FeatureServer/0',
+      id: 'Counties',
+    },
+  ];
+
+  return <WithMap zoom={6} baseLayers={baseLayers} overlays={overlays} />;
+};
 export const landOwnership = () => {
   const landOwnershipOptions = {
     overlays: [

--- a/packages/layer-selector/src/LayerSelectorWithMap.stories.jsx
+++ b/packages/layer-selector/src/LayerSelectorWithMap.stories.jsx
@@ -8,6 +8,7 @@ import WebTileLayer from '@arcgis/core/layers/WebTileLayer';
 import TileLayer from '@arcgis/core/layers/TileLayer';
 import '@arcgis/core/assets/esri/themes/light/main.css';
 import './LayerSelector.css';
+import PropTypes from 'prop-types';
 
 export default {
   title: 'LayerSelector/WithMap',
@@ -54,6 +55,13 @@ const WithMap = ({ center, zoom, scale, baseLayers, overlays }) => {
       ) : null}
     </div>
   );
+};
+WithMap.propTypes = {
+  center: PropTypes.arrayOf(PropTypes.number),
+  zoom: PropTypes.number,
+  scale: PropTypes.number,
+  baseLayers: PropTypes.array,
+  overlays: PropTypes.array,
 };
 
 export const zoom = () => <WithMap zoom={6} />;

--- a/packages/layer-selector/src/LayerSelectorWithMap.stories.jsx
+++ b/packages/layer-selector/src/LayerSelectorWithMap.stories.jsx
@@ -15,7 +15,14 @@ export default {
   component: LayerSelector,
 };
 
-const WithMap = ({ center, zoom, scale, baseLayers, overlays }) => {
+const WithMap = ({
+  center,
+  zoom,
+  scale,
+  baseLayers,
+  overlays,
+  showOpacitySlider,
+}) => {
   const mapDiv = useRef();
   const [layerSelectorOptions, setLayerSelectorOptions] = useState();
 
@@ -39,11 +46,12 @@ const WithMap = ({ center, zoom, scale, baseLayers, overlays }) => {
           : ['Hybrid', 'Lite', 'Terrain', 'Topo', 'Color IR'],
         overlays: overlays ? overlays : ['Address Points'],
         position: 'top-right',
+        showOpacitySlider,
       });
     };
 
     initMap();
-  }, [zoom, center, scale, baseLayers, overlays]);
+  }, [zoom, center, scale, baseLayers, overlays, showOpacitySlider]);
 
   return (
     <div
@@ -62,6 +70,7 @@ WithMap.propTypes = {
   scale: PropTypes.number,
   baseLayers: PropTypes.array,
   overlays: PropTypes.array,
+  showOpacitySlider: PropTypes.bool,
 };
 
 export const zoom = () => <WithMap zoom={6} />;
@@ -159,3 +168,5 @@ export const landOwnership = () => {
 
   return <WithMap {...landOwnershipOptions} />;
 };
+
+export const opacitySlider = () => <WithMap showOpacitySlider zoom={6} />;

--- a/packages/layer-selector/src/__snapshots__/LayerSelector.test.jsx.snap
+++ b/packages/layer-selector/src/__snapshots__/LayerSelector.test.jsx.snap
@@ -80,9 +80,6 @@ exports[`LayerSelector tests > LayerSelector snapshot 1`] = `
               Color IR
             </label>
           </div>
-          <hr
-            class="layer-selector-separator"
-          />
         </div>
       </form>
     </div>

--- a/packages/layer-selector/src/__snapshots__/LayerSelector.test.jsx.snap
+++ b/packages/layer-selector/src/__snapshots__/LayerSelector.test.jsx.snap
@@ -27,12 +27,15 @@ exports[`LayerSelector tests > LayerSelector snapshot 1`] = `
             >
               <input
                 checked=""
-                class="layer-selector-item-input"
                 name="baselayer"
                 type="radio"
                 value="Lite"
               />
-              Lite
+              <span
+                class="layer-selector-item--text"
+              >
+                Lite
+              </span>
             </label>
           </div>
           <div
@@ -42,12 +45,15 @@ exports[`LayerSelector tests > LayerSelector snapshot 1`] = `
               class="layer-selector--item"
             >
               <input
-                class="layer-selector-item-input"
                 name="baselayer"
                 type="radio"
                 value="Terrain"
               />
-              Terrain
+              <span
+                class="layer-selector-item--text"
+              >
+                Terrain
+              </span>
             </label>
           </div>
           <div
@@ -57,12 +63,15 @@ exports[`LayerSelector tests > LayerSelector snapshot 1`] = `
               class="layer-selector--item"
             >
               <input
-                class="layer-selector-item-input"
                 name="baselayer"
                 type="radio"
                 value="Topo"
               />
-              Topo
+              <span
+                class="layer-selector-item--text"
+              >
+                Topo
+              </span>
             </label>
           </div>
           <div
@@ -72,12 +81,15 @@ exports[`LayerSelector tests > LayerSelector snapshot 1`] = `
               class="layer-selector--item"
             >
               <input
-                class="layer-selector-item-input"
                 name="baselayer"
                 type="radio"
                 value="Color IR"
               />
-              Color IR
+              <span
+                class="layer-selector-item--text"
+              >
+                Color IR
+              </span>
             </label>
           </div>
         </div>

--- a/packages/mouse-trap/package.json
+++ b/packages/mouse-trap/package.json
@@ -44,6 +44,7 @@
   ],
   "scripts": {
     "build": "vite build --config ../../vite.config.js",
+    "build:watch": "chokidar \"src/**/*.(js|jsx|css)\" -c \"npm run build\"",
     "test": "vitest --config ../../vite.config.js"
   },
   "dependencies": {

--- a/packages/sherlock/package.json
+++ b/packages/sherlock/package.json
@@ -48,6 +48,7 @@
   ],
   "scripts": {
     "build": "vite build --config ../../vite.config.js",
+    "build:watch": "chokidar \"src/**/*.(js|jsx|css)\" -c \"npm run build\"",
     "test": "vitest --config ../../vite.config.js"
   },
   "dependencies": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -45,6 +45,7 @@
   ],
   "scripts": {
     "build": "vite build --config ../../vite.config.js",
+    "build:watch": "chokidar \"src/**/*.(js|jsx|css)\" -c \"npm run build\"",
     "test": "vitest --config ../../vite.config.js"
   },
   "peerDependencies": {


### PR DESCRIPTION
Add an optional opacity slider stemming from [this request](https://github.com/agrc/wfrc-rtp-projects/issues/64).

Some fixes and refactors including a simplification of the layer item layout and styling.

Before:
![image](https://user-images.githubusercontent.com/1326248/185962653-df89370c-2212-40c9-8c41-fcb0f984f73f.png)

After:
![image](https://user-images.githubusercontent.com/1326248/185962219-b29943c8-a07e-458c-8902-32874225c6f5.png)
