### PR TITLE
feat(layer-selector): add string factory support for TileLayer base layers

### DIFF
--- a/packages/layer-selector/src/LayerSelector.jsx
+++ b/packages/layer-selector/src/LayerSelector.jsx
@@ -9,10 +9,12 @@ import LOD from '@arcgis/core/layers/support/LOD';
 import TileInfo from '@arcgis/core/layers/support/TileInfo';
 import WebTileLayer from '@arcgis/core/layers/WebTileLayer';
 import FeatureLayer from '@arcgis/core/layers/FeatureLayer';
+import TileLayer from '@arcgis/core/layers/TileLayer';
 
 const commonFactories = {
   FeatureLayer,
   WebTileLayer,
+  TileLayer,
 };
 
 const ExpandableContainer = (props) => {

--- a/packages/layer-selector/src/LayerSelectorWithMap.stories.jsx
+++ b/packages/layer-selector/src/LayerSelectorWithMap.stories.jsx
@@ -43,7 +43,19 @@ const WithMap = ({
         quadWord: import.meta.env.VITE_QUAD_WORD,
         baseLayers: baseLayers
           ? baseLayers
-          : ['Hybrid', 'Lite', 'Terrain', 'Topo', 'Color IR'],
+          : [
+              'Hybrid',
+              'Lite',
+              'Terrain',
+              'Topo',
+              'Color IR',
+              {
+                id: 'Vision Refresh Basemap',
+                Factory: 'TileLayer',
+                url: 'https://gis.wfrc.org/arcgis/rest/services/WC2050Vision/2023_Vision_Refresh_Basemap/MapServer/',
+                opacity: 1,
+              },
+            ],
         overlays: overlays ? overlays : ['Address Points'],
         position: 'top-right',
         showOpacitySlider,


### PR DESCRIPTION
This was a request from WFRC for the RTP app. I realize that it's not ideal to include their service in our storybook tests but I couldn't think of a better option. I felt like adding their service was better than nothing.