### PR TITLE
Add tray styling

### DIFF
--- a/packages/layer-selector/src/LayerSelector.jsx
+++ b/packages/layer-selector/src/LayerSelector.jsx
@@ -175,13 +175,7 @@ const createLayerFactories = (
 
 const ConditionalWrapper = ({ condition, wrapper, children }) =>
   condition ? wrapper(children) : children;
-const LayerSelector = (
-  props = {
-    makeExpandable: true,
-    position: 'top-right',
-    showOpacitySlider: false,
-  },
-) => {
+const LayerSelector = (props) => {
   const [layers, setLayers] = useState({
     baseLayers: [],
     overlays: [],
@@ -427,6 +421,7 @@ const LayerSelector = (
   ]);
 
   const onItemChanged = (event, props) => {
+    console.log('LayerSelector.onItemChanged', props);
     const overlays = layers.overlays;
     const baseLayers = layers.baseLayers;
 
@@ -582,6 +577,12 @@ LayerSelector.propTypes = {
   layerType: PropTypes.string,
   id: PropTypes.string,
   showOpacitySlider: PropTypes.bool,
+};
+
+LayerSelector.defaultProps = {
+  makeExpandable: true,
+  position: 'top-right',
+  showOpacitySlider: false,
 };
 
 LayerSelectorItem.propTypes = {

--- a/packages/layer-selector/src/__snapshots__/LayerSelector.test.jsx.snap
+++ b/packages/layer-selector/src/__snapshots__/LayerSelector.test.jsx.snap
@@ -4,81 +4,96 @@ exports[`LayerSelector tests > LayerSelector snapshot 1`] = `
 <DocumentFragment>
   <div>
     <div
-      class="layer-selector--layers"
+      aria-haspopup="true"
+      class="layer-selector"
     >
-      <div
-        class="layer-selector-item radio checkbox"
+      <input
+        alt="layers"
+        class="layer-selector__toggle"
+        src="/packages/layer-selector/src/layers.svg"
+        type="image"
+      />
+      <form
+        class="layer-selector--hidden"
       >
-        <label
-          class="layer-selector--item"
+        <div
+          class="layer-selector--layers"
         >
-          <input
-            checked=""
-            name="baselayer"
-            type="radio"
-            value="Lite"
-          />
-          <span
-            class="layer-selector-item--text"
+          <div
+            class="layer-selector-item radio checkbox"
           >
-            Lite
-          </span>
-        </label>
-      </div>
-      <div
-        class="layer-selector-item radio checkbox"
-      >
-        <label
-          class="layer-selector--item"
-        >
-          <input
-            name="baselayer"
-            type="radio"
-            value="Terrain"
-          />
-          <span
-            class="layer-selector-item--text"
+            <label
+              class="layer-selector--item"
+            >
+              <input
+                checked=""
+                name="baselayer"
+                type="radio"
+                value="Lite"
+              />
+              <span
+                class="layer-selector-item--text"
+              >
+                Lite
+              </span>
+            </label>
+          </div>
+          <div
+            class="layer-selector-item radio checkbox"
           >
-            Terrain
-          </span>
-        </label>
-      </div>
-      <div
-        class="layer-selector-item radio checkbox"
-      >
-        <label
-          class="layer-selector--item"
-        >
-          <input
-            name="baselayer"
-            type="radio"
-            value="Topo"
-          />
-          <span
-            class="layer-selector-item--text"
+            <label
+              class="layer-selector--item"
+            >
+              <input
+                name="baselayer"
+                type="radio"
+                value="Terrain"
+              />
+              <span
+                class="layer-selector-item--text"
+              >
+                Terrain
+              </span>
+            </label>
+          </div>
+          <div
+            class="layer-selector-item radio checkbox"
           >
-            Topo
-          </span>
-        </label>
-      </div>
-      <div
-        class="layer-selector-item radio checkbox"
-      >
-        <label
-          class="layer-selector--item"
-        >
-          <input
-            name="baselayer"
-            type="radio"
-            value="Color IR"
-          />
-          <span
-            class="layer-selector-item--text"
+            <label
+              class="layer-selector--item"
+            >
+              <input
+                name="baselayer"
+                type="radio"
+                value="Topo"
+              />
+              <span
+                class="layer-selector-item--text"
+              >
+                Topo
+              </span>
+            </label>
+          </div>
+          <div
+            class="layer-selector-item radio checkbox"
           >
-            Color IR
-          </span>
-        </label>
-      </div>
+            <label
+              class="layer-selector--item"
+            >
+              <input
+                name="baselayer"
+                type="radio"
+                value="Color IR"
+              />
+              <span
+                class="layer-selector-item--text"
+              >
+                Color IR
+              </span>
+            </label>
+          </div>
+        </div>
+      </form>
     </div>
   </div>
 </DocumentFragment>

--- a/packages/utah-design-system/src/components/Drawer.tsx
+++ b/packages/utah-design-system/src/components/Drawer.tsx
@@ -54,7 +54,7 @@ export const Drawer = ({
         data-type={type}
         data-open={state.isOpen}
         {...(overlayProps || internalOverlayProps)}
-        className='h-full w-80 overflow-y-auto text-zinc-900 duration-500 ease-in-out data-[type="sidebar"]:data-[open="false"]:-translate-x-full data-[type="sidebar"]:data-[open="true"]:translate-x-0 dark:text-zinc-100'
+        className="overflow-y-auto text-zinc-900 duration-500 ease-in-out data-[type='sidebar']:h-full data-[type='sidebar']:w-80 data-[type='sidebar']:data-[open='false']:-translate-x-full data-[type='sidebar']:data-[open='true']:translate-x-0 dark:text-zinc-100"
       >
         {children}
       </aside>
@@ -67,7 +67,7 @@ export const Drawer = ({
 };
 
 const DefaultDrawerTrigger = ({ triggerProps, state }) => (
-  <div className="group absolute -right-8 top-[calc(50%-24px)] z-10 w-6 overflow-hidden rounded rounded-l-none border-l-0 border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-800">
+  <div className="group absolute z-10 w-6 overflow-hidden rounded border-zinc-200 bg-white group-data-[type='sidebar']:-right-8 group-data-[type='sidebar']:top-[calc(50%-24px)] group-data-[type='sidebar']:rounded-l-none group-data-[type='sidebar']:border-l-0 dark:border-zinc-700 dark:bg-zinc-800">
     <Button
       className="flex h-10 w-6 items-center justify-center rounded-none border-0 bg-transparent p-1 shadow-md hover:bg-current group-hover:bg-black/10 dark:group-hover:bg-white/10"
       {...triggerProps}

--- a/packages/utah-design-system/src/components/Drawer.tsx
+++ b/packages/utah-design-system/src/components/Drawer.tsx
@@ -1,7 +1,15 @@
-import { useOverlayTrigger } from 'react-aria';
+import { AriaButtonProps, FocusScope, useOverlayTrigger } from 'react-aria';
+import { DOMProps } from '@react-types/shared';
 import { Button } from './Button';
-import { ChevronLeftIcon, ChevronDownIcon } from '@heroicons/react/24/solid';
-import { twJoin } from 'tailwind-merge';
+import {
+  ChevronLeftIcon,
+  ChevronDownIcon,
+  ArrowsPointingOutIcon,
+} from '@heroicons/react/24/solid';
+import { twJoin, twMerge } from 'tailwind-merge';
+import { tv } from 'tailwind-variants';
+import { useState } from 'react';
+import { OverlayTriggerState } from 'react-stately';
 
 /*
 Getting Started
@@ -9,43 +17,104 @@ Getting Started
 `npm install react-aria react-stately`
 
 const drawerState = useOverlayTriggerState({});
-const overlayTriggerProps = useOverlayTrigger(
+const drawerTriggerProps = useOverlayTrigger(
   {
     type: 'dialog',
   },
   drawerState,
 );
 
-<Drawer state={drawerState} {...overlayTriggerProps}>
+<Drawer state={drawerState} {...drawerTriggerProps}>
   <div className='p-4'>Drawer Content</div>
 </Drawer>
 
 */
 /* default to open
-  const state = useOverlayTrigger({ defaultOpen: true });
-  <Drawer state={state} />
+  const drawerState = useOverlayTrigger({ defaultOpen: true });
+  <Drawer state={drawerState} />
 */
 
-const sidebarContainer =
-  "data-[type='sidebar']:relative data-[type='sidebar']:h-full data-[open='false']:data-[type='sidebar']:w-0 data-[type='sidebar']:w-80 data-[type='sidebar']:transition-[width]";
-const sidebarContent =
-  "data-[type='sidebar']:h-full data-[type='sidebar']:w-80 data-[type='sidebar']:data-[open='false']:-translate-x-full data-[type='sidebar']:data-[open='true']:translate-x-0 data-[type='sidebar']:overflow-y-auto";
-const sidebarTrigger =
-  "group-data-[type='sidebar']:-right-8 group-data-[type='sidebar']:top-[calc(50%-24px)] group-data-[type='sidebar']:w-6 group-data-[type='sidebar']:rounded-l-none group-data-[type='sidebar']:border-l-0";
-const trayContainer =
-  'data-[type="tray"]:absolute data-[type="tray"]:inset-x-0 data-[type="tray"]:bottom-0 data-[type="tray"]:z-20 data-[type="tray"]:h-80 data-[type="tray"]:rounded-t-lg bg-zinc-900 data-[type="tray"]:transition-[height] data-[open="false"]:data-[type="tray"]:h-0 data-[open="true"]:data-[type="tray"]:h-80';
-const trayContent =
-  "data-[type='tray']:h-80 data-[type='tray']:data-[open='false']:overflow-hidden data-[type='tray']:data-[open='true']:translate-y-0 data-[type='tray']:overflow-x-auto";
-const trayTrigger =
-  "group-data-[type='tray']:-top-6 group-data-[type='tray']:rounded-b-none group-data-[type='tray']:border-b-0 roup-data-[type='tray']:w-10 roup-data-[type='tray']:h-6 roup-data-[type='tray']:-top-6 group-data-[type='tray']:left-[calc(50%)] bg-white";
+const drawer = tv({
+  slots: {
+    container:
+      'group shrink-0 bg-white duration-500 ease-in-out dark:bg-zinc-800',
+    content: 'text-zinc-900 duration-500 ease-in-out dark:text-zinc-100',
+    trigger: 'absolute z-10 overflow-hidden rounded border-zinc-200 bg-white ',
+    triggerButton:
+      'flex items-center justify-center rounded-none border-0 bg-transparent p-1 shadow-md hover:bg-current group-hover:bg-black/10 dark:group-hover:bg-white/10',
+  },
+  variants: {
+    type: {
+      sidebar: {
+        container:
+          "relative h-full w-80 transition-[width] data-[open='false']:w-0",
+        content:
+          "h-full w-80 overflow-y-auto data-[open='false']:-translate-x-full data-[open='true']:translate-x-0",
+        trigger:
+          'h-10 w-6 -right-8 top-[calc(50%-24px)] rounded-l-none border-l-0 dark:bg-zinc-800 dark:border-zinc-700',
+        triggerButton: 'h-10 w-full',
+      },
+      tray: {
+        container:
+          'bg-zinc-50 dark:bg-zinc-700 absolute inset-x-0 bottom-0 h-80 transition-[height] data-[open="false"]:h-0 data-[open="true"]:h-80',
+        content:
+          "overflow-x-auto data-[open='false']:h-0 data-[open='true']:h-80 data-[open='true']:translate-y-0 data-[open='false']:overflow-hidden",
+        trigger:
+          'w-10 h-6 -top-6 bg-zinc-50 -top-6 left-[calc(50%-24px)] rounded-b-none border-b-0 dark:bg-zinc-700 dark:border-zinc-800',
+        triggerButton: 'h-6 w-10',
+      },
+    },
+    size: {
+      normal: null,
+      fullscreen: null,
+    },
+  },
+  defaultVariants: {
+    type: 'sidebar',
+    size: 'normal',
+  },
+  compoundVariants: [
+    {
+      type: 'tray',
+      size: 'fullscreen',
+      class: {
+        container:
+          'data-[open="true"]:fixed data-[open="true"]:h-full data-[open="true"]:z-30',
+      },
+    },
+    {
+      type: 'sidebar',
+      size: 'fullscreen',
+      class: {
+        container: 'data-[open="true"]:w-full',
+        content: 'data-[open="true"]:w-full',
+      },
+    },
+  ],
+});
+
+export type DrawerProps = {
+  allowFullScreen?: boolean; // set to true to show the fullscreen button
+  children: React.ReactNode;
+  className?: string;
+  main?: boolean;
+  overlayProps?: DOMProps;
+  state: OverlayTriggerState;
+  triggerProps?: AriaButtonProps;
+  type?: 'sidebar' | 'tray';
+};
+
 export const Drawer = ({
-  triggerProps,
+  children,
+  className,
   overlayProps,
   state,
-  children,
-  type = 'sidebar',
+  triggerProps,
+  allowFullScreen = false,
   main = false,
-}) => {
+  type = 'sidebar',
+}: DrawerProps) => {
+  const [size, setSize] = useState<'normal' | 'fullscreen'>('normal');
   if (!triggerProps || !overlayProps) {
     throw new Error('You must provide both triggerProps and overlayProps');
   }
@@ -55,67 +124,76 @@ export const Drawer = ({
     overlayProps: internalOverlayProps,
   } = useOverlayTrigger({ type: 'dialog' }, state);
 
+  const css = drawer({ type, size });
+
   return (
     <div
       data-open={state.isOpen}
-      data-type={type}
-      className={twJoin(
-        'group shrink-0 duration-500 ease-in-out',
-        sidebarContainer,
-        trayContainer,
-      )}
+      className={twMerge(css.container(), className)}
       id={main ? 'main-content' : undefined}
     >
-      <aside
-        data-type={type}
-        data-open={state.isOpen}
-        {...(overlayProps || internalOverlayProps)}
-        className={twJoin(
-          'text-zinc-900 duration-500 ease-in-out dark:text-zinc-100',
-          sidebarContent,
-          trayContent,
-        )}
-      >
-        {children}
-      </aside>
+      <FocusScope contain={size === 'fullscreen'} restoreFocus>
+        <aside
+          data-open={state.isOpen}
+          className={css.content()}
+          {...(overlayProps || internalOverlayProps)}
+        >
+          {allowFullScreen && (
+            <Button
+              aria-label="Toggle full-screen"
+              className="absolute right-0 top-0 p-2"
+              variant="icon"
+              onPress={() =>
+                setSize(size === 'normal' ? 'fullscreen' : 'normal')
+              }
+            >
+              <ArrowsPointingOutIcon className="h-full w-6 shrink-0 fill-zinc-900 dark:fill-white" />
+            </Button>
+          )}
+          {children}
+        </aside>
+      </FocusScope>
       <DefaultDrawerTrigger
         triggerProps={triggerProps || internalTriggerProps}
         state={state}
-        type={type}
+        Icon={type === 'sidebar' ? ChevronLeftIcon : ChevronDownIcon}
+        className={css.trigger()}
+        buttonClassName={css.triggerButton()}
       />
     </div>
   );
 };
 
-const DefaultDrawerTrigger = ({ triggerProps, type, state }) => (
-  <div
-    className={twJoin(
-      'group absolute z-10 overflow-hidden rounded border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-800',
-      trayTrigger,
-      sidebarTrigger,
-    )}
-  >
-    <Button
-      className="flex items-center justify-center rounded-none border-0 bg-transparent p-1 shadow-md group-data-[type='sidebar']:h-10 group-data-[type='tray']:h-6 group-data-[type='sidebar']:w-6 group-data-[type='tray']:w-10 hover:bg-current group-hover:bg-black/10 dark:group-hover:bg-white/10"
-      {...triggerProps}
-      onPress={state.toggle}
-      aria-label="Close the drawer"
-    >
-      {type === 'sidebar' ? (
-        <ChevronLeftIcon
+export type DefaultDrawerTriggerProps = {
+  triggerProps: AriaButtonProps;
+  Icon: React.ElementType;
+  state: OverlayTriggerState;
+  className?: string;
+  buttonClassName?: string;
+};
+
+const DefaultDrawerTrigger = ({
+  triggerProps,
+  Icon,
+  state,
+  className,
+  buttonClassName,
+}: DefaultDrawerTriggerProps) => {
+  return (
+    <div className={className}>
+      <Button
+        className={buttonClassName}
+        {...triggerProps}
+        onPress={state.toggle}
+        aria-label="Close the drawer"
+      >
+        <Icon
           className={twJoin(
-            'h-6 w-full shrink-0 fill-zinc-900 transition-transform duration-500 dark:fill-white',
+            'size-full shrink-0 fill-zinc-900 transition-transform duration-500 dark:fill-white',
             !state.isOpen ? '-rotate-180' : '',
           )}
         />
-      ) : (
-        <ChevronDownIcon
-          className={twJoin(
-            'h-6 w-full shrink-0 fill-zinc-900 transition-transform duration-500 dark:fill-white',
-            !state.isOpen ? '-rotate-180' : '',
-          )}
-        />
-      )}
-    </Button>
-  </div>
-);
+      </Button>
+    </div>
+  );
+};

--- a/packages/utah-design-system/src/components/Drawer.tsx
+++ b/packages/utah-design-system/src/components/Drawer.tsx
@@ -1,6 +1,6 @@
 import { useOverlayTrigger } from 'react-aria';
 import { Button } from './Button';
-import { ChevronLeftIcon } from '@heroicons/react/24/solid';
+import { ChevronLeftIcon, ChevronDownIcon } from '@heroicons/react/24/solid';
 import { twJoin } from 'tailwind-merge';
 
 /*
@@ -26,6 +26,18 @@ const overlayTriggerProps = useOverlayTrigger(
   <Drawer state={state} />
 */
 
+const sidebarContainer =
+  "data-[type='sidebar']:relative data-[type='sidebar']:h-full data-[open='false']:data-[type='sidebar']:w-0 data-[type='sidebar']:w-80 data-[type='sidebar']:transition-[width]";
+const sidebarContent =
+  "data-[type='sidebar']:h-full data-[type='sidebar']:w-80 data-[type='sidebar']:data-[open='false']:-translate-x-full data-[type='sidebar']:data-[open='true']:translate-x-0 data-[type='sidebar']:overflow-y-auto";
+const sidebarTrigger =
+  "group-data-[type='sidebar']:-right-8 group-data-[type='sidebar']:top-[calc(50%-24px)] group-data-[type='sidebar']:w-6 group-data-[type='sidebar']:rounded-l-none group-data-[type='sidebar']:border-l-0";
+const trayContainer =
+  'data-[type="tray"]:absolute data-[type="tray"]:inset-x-0 data-[type="tray"]:bottom-0 data-[type="tray"]:z-20 data-[type="tray"]:h-80 data-[type="tray"]:rounded-t-lg bg-zinc-900 data-[type="tray"]:transition-[height] data-[open="false"]:data-[type="tray"]:h-0 data-[open="true"]:data-[type="tray"]:h-80';
+const trayContent =
+  "data-[type='tray']:h-80 data-[type='tray']:data-[open='false']:overflow-hidden data-[type='tray']:data-[open='true']:translate-y-0 data-[type='tray']:overflow-x-auto";
+const trayTrigger =
+  "group-data-[type='tray']:-top-6 group-data-[type='tray']:rounded-b-none group-data-[type='tray']:border-b-0 roup-data-[type='tray']:w-10 roup-data-[type='tray']:h-6 roup-data-[type='tray']:-top-6 group-data-[type='tray']:left-[calc(50%)] bg-white";
 export const Drawer = ({
   triggerProps,
   overlayProps,
@@ -47,39 +59,63 @@ export const Drawer = ({
     <div
       data-open={state.isOpen}
       data-type={type}
-      className="relative h-full w-80 shrink-0 transition-[width] duration-500 ease-in-out data-[open='false']:w-0"
+      className={twJoin(
+        'group shrink-0 duration-500 ease-in-out',
+        sidebarContainer,
+        trayContainer,
+      )}
       id={main ? 'main-content' : undefined}
     >
       <aside
         data-type={type}
         data-open={state.isOpen}
         {...(overlayProps || internalOverlayProps)}
-        className="overflow-y-auto text-zinc-900 duration-500 ease-in-out data-[type='sidebar']:h-full data-[type='sidebar']:w-80 data-[type='sidebar']:data-[open='false']:-translate-x-full data-[type='sidebar']:data-[open='true']:translate-x-0 dark:text-zinc-100"
+        className={twJoin(
+          'text-zinc-900 duration-500 ease-in-out dark:text-zinc-100',
+          sidebarContent,
+          trayContent,
+        )}
       >
         {children}
       </aside>
       <DefaultDrawerTrigger
         triggerProps={triggerProps || internalTriggerProps}
         state={state}
+        type={type}
       />
     </div>
   );
 };
 
-const DefaultDrawerTrigger = ({ triggerProps, state }) => (
-  <div className="group absolute z-10 w-6 overflow-hidden rounded border-zinc-200 bg-white group-data-[type='sidebar']:-right-8 group-data-[type='sidebar']:top-[calc(50%-24px)] group-data-[type='sidebar']:rounded-l-none group-data-[type='sidebar']:border-l-0 dark:border-zinc-700 dark:bg-zinc-800">
+const DefaultDrawerTrigger = ({ triggerProps, type, state }) => (
+  <div
+    className={twJoin(
+      'group absolute z-10 overflow-hidden rounded border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-800',
+      trayTrigger,
+      sidebarTrigger,
+    )}
+  >
     <Button
-      className="flex h-10 w-6 items-center justify-center rounded-none border-0 bg-transparent p-1 shadow-md hover:bg-current group-hover:bg-black/10 dark:group-hover:bg-white/10"
+      className="flex items-center justify-center rounded-none border-0 bg-transparent p-1 shadow-md group-data-[type='sidebar']:h-10 group-data-[type='tray']:h-6 group-data-[type='sidebar']:w-6 group-data-[type='tray']:w-10 hover:bg-current group-hover:bg-black/10 dark:group-hover:bg-white/10"
       {...triggerProps}
       onPress={state.toggle}
       aria-label="Close the drawer"
     >
-      <ChevronLeftIcon
-        className={twJoin(
-          'h-6 w-full shrink-0 fill-zinc-900 transition-transform duration-500 dark:fill-white',
-          !state.isOpen ? '-rotate-180' : '',
-        )}
-      />
+      {type === 'sidebar' ? (
+        <ChevronLeftIcon
+          className={twJoin(
+            'h-6 w-full shrink-0 fill-zinc-900 transition-transform duration-500 dark:fill-white',
+            !state.isOpen ? '-rotate-180' : '',
+          )}
+        />
+      ) : (
+        <ChevronDownIcon
+          className={twJoin(
+            'h-6 w-full shrink-0 fill-zinc-900 transition-transform duration-500 dark:fill-white',
+            !state.isOpen ? '-rotate-180' : '',
+          )}
+        />
+      )}
     </Button>
   </div>
 );

--- a/packages/utah-design-system/src/components/SocialMedia.jsx
+++ b/packages/utah-design-system/src/components/SocialMedia.jsx
@@ -1,9 +1,9 @@
 export const SocialMedia = () => (
-  <div className="flex flex-col items-center gap-1 bg-primary-900 px-8 py-2 text-zinc-50 dark:bg-zinc-800 sm:flex-row sm:gap-4 sm:py-0">
+  <div className="flex flex-col items-center gap-1 bg-primary-900 py-2 text-zinc-50 dark:bg-zinc-800 sm:flex-row sm:gap-4 sm:py-0 md:px-8">
     <div className="order-last text-sm font-medium uppercase sm:order-first">
       Connect with us
     </div>
-    <div className="sm:flex-0 flex items-center gap-1">
+    <div className="flex items-center gap-1 sm:flex-none">
       <a
         href="mailto:ugrc@utah.gov"
         className="custom-style focus:ring-accent flex grow items-center justify-center rounded-full p-2 transition-all ease-in-out hover:bg-white/20 focus:outline-none focus:ring-4"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "skipLibCheck": true
   },
-  "include": ["src", "stories"]
+  "include": ["packages", "src"]
 }


### PR DESCRIPTION
This separates the sidebar from the tray styles. This is very much rough and unfinished.

I wanted the tray to come up from underneath the map and side bar drawer in atlas but visually be on top of them. This is basically working but the content does not collapse to a 0 height when it is closed. 