### PR TITLE
fix(sherlock): order search results for map service provider

### DIFF
--- a/packages/utah-design-system/src/components/Sherlock.jsx
+++ b/packages/utah-design-system/src/components/Sherlock.jsx
@@ -275,6 +275,7 @@ export const featureServiceProvider = (
         returnGeometry: false,
         resultRecordCount: maxResults,
         returnDistinctValues: true,
+        orderByFields: searchField,
       });
 
       const responseJson = await safeFetch(


### PR DESCRIPTION
This fixes queries to ArcGIS Server 10.9.1. Prior to this change, they were throwing error logs like this:

Geodatabase error: Underlying DBMS error [[Microsoft][ODBC Driver 17 for SQL Server][SQL Server]ORDER BY items must appear in the select list if SELECT DISTINCT is specified.]

This was happening on the test server for electrofishing.