### PR TITLE
fix(layer-selector): add drop shadow to match other esri map widgets

### DIFF
--- a/packages/layer-selector/src/LayerSelector.css
+++ b/packages/layer-selector/src/LayerSelector.css
@@ -30,6 +30,9 @@
   background: #fff;
   pointer-events: auto;
 }
+.layer-selector.esri-component.esri-widget {
+  margin-bottom: 0;
+}
 .layer-selector--width {
   width: 8em;
 }

--- a/packages/layer-selector/src/LayerSelector.jsx
+++ b/packages/layer-selector/src/LayerSelector.jsx
@@ -30,7 +30,7 @@ const ExpandableContainer = (props) => {
   return (
     // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
     <div
-      className="layer-selector"
+      className="layer-selector esri-component esri-widget"
       // onFocus={() => setExpanded(true)}
       // onBlur={() => setExpanded(false)}
       onMouseOver={() => setExpanded(true)}

--- a/packages/layer-selector/src/__snapshots__/LayerSelector.test.jsx.snap
+++ b/packages/layer-selector/src/__snapshots__/LayerSelector.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`LayerSelector tests > LayerSelector snapshot 1`] = `
   <div>
     <div
       aria-haspopup="true"
-      class="layer-selector"
+      class="layer-selector esri-component esri-widget"
     >
       <input
         alt="layers"


### PR DESCRIPTION
This must have broken in a recent esri js release.