### PR TITLE
fix(TextField): add support for `inputProps.className`

### DIFF
--- a/packages/utah-design-system/src/components/TextField.stories.tsx
+++ b/packages/utah-design-system/src/components/TextField.stories.tsx
@@ -19,6 +19,14 @@ export default meta;
 
 export const Example = {};
 
+export const Large = {
+  args: {
+    inputProps: {
+      className: 'text-2xl',
+    },
+  },
+};
+
 export const HtmlValidation = (args: any) => (
   <form
     onSubmit={(event) => {

--- a/packages/utah-design-system/src/components/TextField.tsx
+++ b/packages/utah-design-system/src/components/TextField.tsx
@@ -5,6 +5,7 @@ import {
   type InputProps,
   type ValidationResult,
 } from 'react-aria-components';
+import { twJoin } from 'tailwind-merge';
 import { tv } from 'tailwind-variants';
 import {
   Description,
@@ -35,6 +36,12 @@ export const TextField = forwardRef(function TextField(
   { label, description, errorMessage, inputProps, ...props }: TextFieldProps,
   ref: ForwardedRef<HTMLInputElement>,
 ) {
+  // mix in input classes if necessary
+  let inputClasses = inputStyles();
+  if (inputProps?.className) {
+    inputClasses = twJoin(inputStyles(), inputProps.className as string);
+  }
+
   return (
     <AriaTextField
       {...props}
@@ -44,7 +51,7 @@ export const TextField = forwardRef(function TextField(
       )}
     >
       {label && <Label>{label}</Label>}
-      <Input ref={ref} {...inputProps} className={inputStyles} />
+      <Input ref={ref} {...inputProps} className={inputClasses} />
       {description && <Description>{description}</Description>}
       <FieldError>{errorMessage}</FieldError>
     </AriaTextField>


### PR DESCRIPTION
This is just an idea. I wanted to make the TextField for address verification larger since it's the star of the show.

The other option that I thought of is to create a size prop.