### PR TITLE
Replace deprecated watch method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14372,9 +14372,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "16.17.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-16.17.0.tgz",
-      "integrity": "sha512-jJ7oLh0dL4MH3RryActHTILZjfya6JJcttdUJjcROpr/fKxbz3lkhTn+ufQ0kiL5AjC5m28JisurHPn4yo+nqw==",
+      "version": "16.18.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-16.18.0.tgz",
+      "integrity": "sha512-23AmvwFSvnMqNRHrSTc+rjTZNMY7YN4JbrPMqAZRIpNNpv9GU0XO1U2IQ9QzNuTNp/sxUU/2gT+9pi7Nu7OntQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/utilities/src/hooks/useViewLoading.ts
+++ b/packages/utilities/src/hooks/useViewLoading.ts
@@ -1,3 +1,4 @@
+import { watch } from '@arcgis/core/core/reactiveUtils';
 import { useEffect, useRef, useState } from 'react';
 
 export default function useViewLoading(
@@ -13,24 +14,27 @@ export default function useViewLoading(
     }
 
     view.when(() => {
-      view.watch('updating', (updating: boolean) => {
-        if (updating && timeoutId.current) {
-          return;
-        }
-
-        if (!updating) {
-          if (timeoutId.current) {
-            clearTimeout(timeoutId.current);
-            timeoutId.current = null;
+      watch(
+        () => view.updating,
+        (updating: boolean) => {
+          if (updating && timeoutId.current) {
+            return;
           }
-          setIsLoading(false);
-        } else {
-          timeoutId.current = setTimeout(() => {
-            setIsLoading(true);
-            timeoutId.current = null;
-          }, debounceDuration);
-        }
-      });
+
+          if (!updating) {
+            if (timeoutId.current) {
+              clearTimeout(timeoutId.current);
+              timeoutId.current = null;
+            }
+            setIsLoading(false);
+          } else {
+            timeoutId.current = setTimeout(() => {
+              setIsLoading(true);
+              timeoutId.current = null;
+            }, debounceDuration);
+          }
+        },
+      );
     });
   }, [debounceDuration, view]);
 


### PR DESCRIPTION
[esri.views.MapView] 🛑 DEPRECATED - Function: `watch` is deprecated in favor of reactiveUtils.watch()
🛠️ Replacement: reactiveUtils.watch