### PR TITLE
Protect hooks from immediate resolution

### DIFF
--- a/packages/utilities/src/hooks/useDefaultExtent.ts
+++ b/packages/utilities/src/hooks/useDefaultExtent.ts
@@ -21,7 +21,11 @@ export const useDefaultExtent = (
       return;
     }
 
-    whenOnce(() => view.ready).then(() => view.goTo(extent));
+    whenOnce(() => view.ready)
+      .then(() => view.goTo(extent))
+      .catch((error) => {
+        console.error('Failed to navigate to the extent:', error);
+      });
   };
 
   return goHome;

--- a/packages/utilities/src/hooks/useDefaultExtent.ts
+++ b/packages/utilities/src/hooks/useDefaultExtent.ts
@@ -1,3 +1,4 @@
+import { whenOnce } from '@arcgis/core/core/reactiveUtils';
 import Extent from '@arcgis/core/geometry/Extent';
 import { useState } from 'react';
 
@@ -20,9 +21,7 @@ export const useDefaultExtent = (
       return;
     }
 
-    view.when(() => {
-      view.goTo(extent);
-    });
+    whenOnce(() => view.ready).then(() => view.goTo(extent));
   };
 
   return goHome;

--- a/packages/utilities/src/hooks/useGraphicManager.ts
+++ b/packages/utilities/src/hooks/useGraphicManager.ts
@@ -1,3 +1,4 @@
+import { whenOnce } from '@arcgis/core/core/reactiveUtils';
 import Graphic from '@arcgis/core/Graphic.js';
 import MapView from '@arcgis/core/views/MapView.js';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -59,9 +60,9 @@ const useGraphicManager = (
         );
       }
 
-      mapView?.when(() => {
-        mapView.graphics.addMany(graphic);
-      });
+      whenOnce(() => mapView.ready).then(() =>
+        mapView.graphics.addMany(graphic),
+      );
     } else {
       if (graphic && graphic.declaredClass !== 'esri.Graphic') {
         console.warn(
@@ -69,7 +70,7 @@ const useGraphicManager = (
         );
       }
 
-      mapView?.when(() => {
+      whenOnce(() => mapView.ready).then(() => {
         if (graphic) {
           mapView.graphics.add(graphic);
         }

--- a/packages/utilities/src/hooks/useMapReady.ts
+++ b/packages/utilities/src/hooks/useMapReady.ts
@@ -1,13 +1,11 @@
+import { whenOnce } from '@arcgis/core/core/reactiveUtils';
 import { useState } from 'react';
 
 export default function useMapReady(view: __esri.MapView | null) {
   const [ready, setReady] = useState(false);
-  const [callbackRegistered, setCallbackRegistered] = useState(false);
 
-  if (view && !callbackRegistered) {
-    view.when(() => setReady(true));
-
-    setCallbackRegistered(true);
+  if (view) {
+    whenOnce(() => view.ready).then(() => setReady(true));
   }
 
   return ready;

--- a/packages/utilities/src/hooks/useViewLoading.ts
+++ b/packages/utilities/src/hooks/useViewLoading.ts
@@ -1,4 +1,4 @@
-import { watch } from '@arcgis/core/core/reactiveUtils';
+import { watch, whenOnce } from '@arcgis/core/core/reactiveUtils';
 import { useEffect, useRef, useState } from 'react';
 
 export default function useViewLoading(
@@ -13,7 +13,7 @@ export default function useViewLoading(
       return;
     }
 
-    view.when(() => {
+    whenOnce(() => view.ready).then(() => {
       watch(
         () => view.updating,
         (updating: boolean) => {

--- a/packages/utilities/src/hooks/useViewPointZooming.ts
+++ b/packages/utilities/src/hooks/useViewPointZooming.ts
@@ -1,3 +1,4 @@
+import { whenOnce } from '@arcgis/core/core/reactiveUtils';
 import { useEffect, useState } from 'react';
 
 export default function useViewPointZooming(mapView: __esri.MapView) {
@@ -5,7 +6,9 @@ export default function useViewPointZooming(mapView: __esri.MapView) {
 
   useEffect(() => {
     if (viewPoint) {
-      mapView.when(() => mapView.goTo(viewPoint).catch(() => {}));
+      whenOnce(() => mapView.ready).then(() =>
+        mapView.goTo(viewPoint).catch(() => {}),
+      );
     }
   }, [viewPoint, mapView]);
 


### PR DESCRIPTION
Calling view.when() while the view is no longer ready but was already resolved once will resolve immediately.

This helps apps that have screens with a map that you can navigate to and from on.

I struggled to pnpm link this package and had to vendor to test. Have you had any better luck?