### PR TITLE
feat(layer-selector): add support for basemap configs

### DIFF
--- a/packages/utah-design-system/README.md
+++ b/packages/utah-design-system/README.md
@@ -2,11 +2,15 @@
 
 This is UGRC's [React Aria](https://react-spectrum.adobe.com/react-aria/) plus [Tailwind CSS](https://tailwindcss.com/) implementation of the [Utah Design System](https://designsystem.utah.gov/).
 
+## Tailwind Colors
+
 This design system expects Tailwind CSS primary, secondary, and accent colors ranging from 50-950. The UGRC default presets can be used for this from [@ugrc/tailwind-preset](https://www.npmjs.com/package/@ugrc/tailwind-preset).
+
+## Header
 
 The Header component requires a custom font for the SVG text.
 
-## Remote
+### Remote
 
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -17,7 +21,7 @@ The Header component requires a custom font for the SVG text.
 />
 ```
 
-## Local
+### Local
 
 ```css
 @font-face {
@@ -36,3 +40,9 @@ The Header component requires a custom font for the SVG text.
   font-display: swap;
 }
 ```
+
+## Layer Selector
+
+This is a component that allows the user to quickly toggle visibility of layers or base maps in a web map. It has `baseLayers`, `operationalLayers`, and `referenceLayers` options that allow you to add layers to the corresponding properties of your map's [Basemap](https://developers.arcgis.com/javascript/latest/api-reference/esri-Basemap.html). It also supports adding entire base maps via the `basemaps` property. When this property is used, the individual parts of the base map (`baseLayers` and `referenceLayers`) are mixed into the base map that Layer Selector manages.
+
+Layers defined in `baseLayers` or `basemaps` are represented as a radio buttons in a single group. You are required to pass at least one value to at least one of these properties. The first value in `basemaps` is selected by default. If no value is passed to `basemaps`, then the first value in `baseLayers` is selected by default. The `operationalLayers` and `referenceLayers` properties are represented as checkboxes.

--- a/packages/utah-design-system/src/components/LayerSelector.stories.tsx
+++ b/packages/utah-design-system/src/components/LayerSelector.stories.tsx
@@ -1,3 +1,4 @@
+import Basemap from '@arcgis/core/Basemap';
 import { watch } from '@arcgis/core/core/reactiveUtils';
 import FeatureLayer from '@arcgis/core/layers/FeatureLayer';
 import LOD from '@arcgis/core/layers/support/LOD';
@@ -77,6 +78,18 @@ export function Default({
       options: {
         view,
         quadWord: import.meta.env.VITE_QUAD_WORD,
+        basemaps: [
+          {
+            label: 'Vector Lite',
+            function: () =>
+              new Basemap({
+                portalItem: {
+                  id: '98104c602b7c44419c0a952f28c65815',
+                },
+              }),
+          },
+          'Lite', // this is for testing the happy path tokens
+        ],
         baseLayers: baseLayers || [
           'Hybrid',
           {
@@ -86,7 +99,6 @@ export function Default({
                 url: 'https://gis.wfrc.org/arcgis/rest/services/WC2050Vision/2023_Vision_Refresh_Basemap/MapServer',
               }),
           },
-          'Lite',
           'Terrain',
           'Topo',
           'Color IR',

--- a/packages/utah-design-system/src/components/LayerSelector.types.ts
+++ b/packages/utah-design-system/src/components/LayerSelector.types.ts
@@ -1,15 +1,37 @@
 export type LayerConfig = {
-  /** label that shows up next to the radio button or checkbox */
+  /** Label that shows up next to the radio button or checkbox */
   label: string;
-  /** function that creates the layer, not called until the layer is toggled on */
+  /** Function that creates the layer, not called until the layer is toggled on */
   function: () => __esri.Layer;
-  /** whether the layer is selected by default on load, only relevant for operationalLayers and referenceLayers, the first baseLayer is always selected by default */
+  /**
+   * Controls whether the layer is initially selected.
+   * - For operationalLayers and referenceLayers: this determines if the layer is on by default
+   * - For basemaps: the first basemap is always selected by default
+   * - If no basemap configs exist, the first baseLayer is selected by default
+   */
   defaultSelected?: boolean;
 };
+
+export type BasemapConfig = {
+  function: () => __esri.Basemap;
+} & Omit<LayerConfig, 'function'>;
+export type BasemapConfigOrToken = BasemapConfig | BasemapToken;
+
 export type LayerConfigOrToken = LayerConfig | LayerToken;
 export type BaseLayerConfigOrToken =
   | Omit<LayerConfig, 'defaultSelected'>
   | LayerToken;
+
+export const basemapTokens = {
+  imagery: 'Imagery',
+  topo: 'Topo',
+  terrain: 'Terrain',
+  lite: 'Lite',
+  colorIR: 'Color IR',
+  hybrid: 'Hybrid',
+} as const;
+
+export type BasemapToken = (typeof basemapTokens)[keyof typeof basemapTokens];
 
 export const layerTokens = {
   imagery: 'Imagery',


### PR DESCRIPTION
This PR adds support for passing entire basemap objects rather than just individual layers. The use case is the new Vector Lite Base Map. I've tested this in Atlas and it seems to work well.