### PR TITLE
fix(layer-selector): prevent duplicate layers from being added to the map

### DIFF
--- a/packages/utah-design-system/src/components/LayerSelector.tsx
+++ b/packages/utah-design-system/src/components/LayerSelector.tsx
@@ -108,7 +108,9 @@ export async function toggleLayer(
       managedObjects[label] = layer;
     }
 
-    container.add(layer);
+    if (!container.includes(layer)) {
+      container.add(layer);
+    }
   } else {
     // remove layer if it exists
     if (layer) {


### PR DESCRIPTION
This bug is showing up in at least a few apps. I first saw it in WRI and was able to reproduce it in Atlas by switching to the `baseLayers` prop.

This logic is already in the `toggleBasemap` function. I think that this was just an oversight.