### PR TITLE
fix(uds): make view input param type more permissive

### DIFF
--- a/packages/utilities/src/hooks/useViewLoading.ts
+++ b/packages/utilities/src/hooks/useViewLoading.ts
@@ -2,7 +2,7 @@ import { watch, whenOnce } from '@arcgis/core/core/reactiveUtils';
 import { useEffect, useRef, useState } from 'react';
 
 export default function useViewLoading(
-  view: __esri.MapView | null,
+  view: __esri.MapView | null | undefined,
   debounceDuration = 500,
 ) {
   const [isLoading, setIsLoading] = useState(false);


### PR DESCRIPTION
In this case, we do not care if it's null or undefined. When working with the new map component, mapRef.current.view can be undefined.