### PR TITLE
fix(fileinput): fix description contrast in dark mode

### DIFF
--- a/packages/utah-design-system/src/components/Field.tsx
+++ b/packages/utah-design-system/src/components/Field.tsx
@@ -35,7 +35,10 @@ export function Description(props: TextProps) {
     <Text
       {...props}
       slot="description"
-      className={twMerge('text-sm text-gray-600', props.className)}
+      className={twMerge(
+        'text-sm text-gray-600 dark:text-zinc-400',
+        props.className,
+      )}
     />
   );
 }


### PR DESCRIPTION
The WAVE tool shows a warning and error because the label does not have a corresponding form control and the hidden input does not have a corresponding label. I couldn't figure out a way to connect the two. The hidden input does not have any id attribute.